### PR TITLE
Fix filter fields regexp and corner case parsing 

### DIFF
--- a/ngx_http_upload_module.c
+++ b/ngx_http_upload_module.c
@@ -873,6 +873,16 @@ ngx_http_read_upload_client_request_body(ngx_http_request_t *r)
 
             rc = ngx_http_do_read_client_request_body(r);
             goto done;
+        } else if (rb->rest == 0) {
+            /* everything already read in ngx_http_request_body_filter */
+            ngx_log_debug0(NGX_LOG_DEBUG_HTTP, r->connection->log, 0, "http client request body fully read in ngx_http_request_body_filter");
+
+            if (r->connection->read->timer_set) {
+                ngx_del_timer(r->connection->read);
+            }
+            upload_shutdown_ctx(u);
+
+            return ngx_http_upload_body_handler(r);
         }
 
     } else {

--- a/ngx_http_upload_module.c
+++ b/ngx_http_upload_module.c
@@ -1885,7 +1885,7 @@ static ngx_int_t ngx_http_upload_start_handler(ngx_http_upload_ctx_t *u) { /* {{
                 /*
                  * If at least one filter succeeds, we pass the field
                  */
-                if(rc == 0)
+                if(rc >= 0)
                     pass_field = 1;
 #else
                 if(ngx_strncmp(f[i].text.data, u->field_name.data, u->field_name.len) == 0)


### PR DESCRIPTION
This PR addresses two issues:

- when NGIX_PCRE is used, the return value of ngx_pcre can be > 0 in case of a match, which result in fields being ignored by the filter
- sometime the full request, headers and body, are contained in preread size and the upload sequence does not go on, leaving downstream connection pending forever

Verified with nginx 1.21.0 and 1.21.6